### PR TITLE
chore(build): trim unused entries from version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright © 2024, 2025 Caleb Cushing
+# SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,59 +1,21 @@
-# SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
+# SPDX-FileCopyrightText: Copyright © 2024, 2025 Caleb Cushing
 #
 # SPDX-License-Identifier: CC0-1.0
 
 [versions]
-checker = "3.+"
 ep = "2.+"
 plugin-convention = "0.+"
-spring = "3.+"
 
 [libraries]
-api-guardian = { module = "org.apiguardian:apiguardian-api" }
 assertj = "org.assertj:assertj-core:3.+"
-autoservice = "com.google.auto.service:auto-service:1.+"
-checker-annotations = { module = "org.checkerframework:checker-qual", version.ref = "checker" }
-checker-core = { module = "org.checkerframework:checker", version.ref = "checker" }
 commons-io = "commons-io:commons-io:2.+"
-commons-lang = "org.apache.commons:commons-lang3:3.+"
-compile-testing = "com.google.testing.compile:compile-testing:0.+"
-equalsverifier = "nl.jqno.equalsverifier:equalsverifier:4.+"
-errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "ep" }
 errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "ep" }
 errorprone-nullaway = "com.uber.nullaway:nullaway:0.+"
-google-java-format = "com.google.googlejavaformat:google-java-format:+"
-guava = "com.google.guava:guava:+"
-h2 = { module = "com.h2database:h2" }
-hibernate-envers = { module = "org.hibernate.orm:hibernate-envers" }
-hibernate-jpa-modelgen = { module = "org.hibernate.orm:hibernate-jpamodelgen" }
-hibernate-orm-core = { module = "org.hibernate.orm:hibernate-core" }
-immutables-annotate = { module = "org.immutables:annotate" }
-immutables-annotations = { module = "org.immutables:value-annotations" }
-immutables-bom = "org.immutables:bom:2.+"
-immutables-builder = { module = "org.immutables:builder" }
-immutables-core = { module = "org.immutables:value" }
-jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
-jackson-core = { module = "com.fasterxml.jackson.core:jackson-core" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
-jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml" }
-jackson-module-parameter-names = { module = "com.fasterxml.jackson.module:jackson-module-parameter-names" }
-jakarta-annotation = { module = "jakarta.annotation:jakarta.annotation-api" }
-jakarta-persistence = { module = "jakarta.persistence:jakarta.persistence-api" }
-jakarta-servlet = { module = "jakarta.servlet:jakarta.servlet-api" }
-jakarta-validation = { module = "jakarta.validation:jakarta.validation-api" }
-java-parser = "com.github.javaparser:javaparser-core:3.+"
-java-tools = "com.xenoterracide:tools:0.+"
-jetbrains-annotations = "org.jetbrains:annotations:+"
-jgit = "org.eclipse.jgit:org.eclipse.jgit:7.+"
-jspecify = "org.jspecify:jspecify:1.+"
-junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-bom = "org.junit:junit-bom:5.+"
+junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-parameters = { module = "org.junit.jupiter:junit-jupiter-params" }
-log4j-api = { module = "org.apache.logging.log4j:log4j-api" }
-maven-artifact = "org.apache.maven:maven-artifact:3.+"
-mockito = { module = "org.mockito:mockito-core", version = "5.+" }
 plugin-convention-checkstyle = { module = "com.xenoterracide.gradle.convention:checkstyle", version.ref = "plugin-convention" }
 plugin-convention-coverage = { module = "com.xenoterracide.gradle.convention:coverage", version.ref = "plugin-convention" }
 plugin-convention-publish = { module = "com.xenoterracide.gradle.convention:publish", version.ref = "plugin-convention" }
@@ -61,68 +23,15 @@ plugin-convention-spotbugs = { module = "com.xenoterracide.gradle.convention:spo
 plugin-dependency-analysis = "com.autonomousapps:dependency-analysis-gradle-plugin:2.+"
 plugin-errorprone = "net.ltgt.gradle:gradle-errorprone-plugin:4.+"
 plugin-gradle-plugin-publish = "com.gradle.publish:plugin-publish-plugin:1.+"
-plugin-semver = "com.xenoterracide.gradle:semver:0.+"
 plugin-spotbugs = "com.github.spotbugs:com.github.spotbugs.gradle.plugin:6.+"
-semver = "org.semver4j:semver4j:5.+"
-slf4j-api = { module = "org.slf4j:slf4j-api" }
-slf4j-bom = "org.slf4j:slf4j-bom:2.+"
-slf4j-nop = { module = "org.slf4j:slf4j-nop" }
-slf4j-simple = { module = "org.slf4j:slf4j-simple" }
 spotbugs = "com.github.spotbugs:spotbugs:4.+"
-spring-beans = { module = "org.springframework:spring-beans" }
-spring-bom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring" }
-spring-boot-actuator = { module = "org.springframework.boot:spring-boot-actuator" }
-spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure" }
-spring-boot-core = { module = "org.springframework.boot:spring-boot" }
-spring-boot-devtools = { module = "org.springframework.boot:spring-boot-devtools" }
-spring-boot-test-autoconfigure = { module = "org.springframework.boot:spring-boot-test-autoconfigure" }
-spring-boot-test-core = { module = "org.springframework.boot:spring-boot-test" }
-spring-context = { module = "org.springframework:spring-context" }
-spring-core = { module = "org.springframework:spring-core" }
-spring-data-commons = { module = "org.springframework.data:spring-data-commons" }
-spring-data-envers = { module = "org.springframework.data:spring-data-envers" }
-spring-data-jpa = { module = "org.springframework.data:spring-data-jpa" }
-spring-data-neo4j = { module = "org.springframework.data:spring-data-neo4j" }
-spring-instrument = { module = "org.springframework:spring-instrument" }
-spring-orm = { module = "org.springframework:spring-orm" }
-spring-security-config = { module = "org.springframework.security:spring-security-config" }
-spring-security-core = { module = "org.springframework.security:spring-security-core" }
-spring-security-oauth2-authorization-server = { module = "org.springframework.security:spring-security-oauth2-authorization-server" }
-spring-security-oauth2-core = { module = "org.springframework.security:spring-security-oauth2" }
-spring-security-web = { module = "org.springframework.security:spring-security-web" }
-spring-test = { module = "org.springframework:spring-test" }
-spring-transaction = { module = "org.springframework:spring-tx" }
-spring-web = { module = "org.springframework:spring-web" }
-spring-webmvc = { module = "org.springframework:spring-webmvc" }
-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
-starter-core = { module = "org.springframework.boot:spring-boot-starter" }
-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
-starter-jackson = { module = "org.springframework.boot:spring-boot-starter-jackson" }
-starter-log4j2 = { module = "org.springframework.boot:spring-boot-starter-log4j2" }
-starter-neo4j = { module = "org.springframework.boot:spring-boot-starter-data-neo4j" }
-starter-oauth2-client = { module = "org.springframework.boot:spring-boot-starter-oauth2-client" }
-starter-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server" }
-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
-testcontainers = "org.testcontainers:junit-jupiter:1.+"
-uuid-creator = "com.github.f4b6a3:uuid-creator:6.+"
-vavr = "io.vavr:vavr:0.+"
+jspecify = "org.jspecify:jspecify:1.+"
 
 [bundles]
 compile = ["jspecify"]
 ep = ["errorprone-core", "errorprone-nullaway"]
-immutables = ["immutables-annotations", "immutables-builder", "immutables-annotate"]
-jackson-config = ["jackson-core", "jackson-module-parameter-names"]
-spring-test = ["spring-test", "spring-boot-test-core", "spring-boot-autoconfigure", "spring-boot-test-autoconfigure"]
 test-impl = ["junit-api", "assertj", "junit-parameters"]
 test-runtime = ["junit-engine", "junit-launcher"]
 
 [plugins]
-dependency-analysis = { id = "com.autonomousapps.dependency-analysis" }
-gradle-plugin-publish = { id = "com.gradle.plugin-publish", version = "2.+" }
 semver = { id = "com.xenoterracide.gradle.semver", version = "0.13.+" }
-shadow = { id = "com.gradleup.shadow", version = "8.+" }
-spring-boot = { id = "org.springframework.boot", version.ref = "spring" }


### PR DESCRIPTION
Remove aliases, bundles, and plugin ids that are not referenced anywhere in the project (root build, modules, or buildSrc). Keeps only the dependencies actually used by Gradle scripts and dependency-analysis excludes.\n\nCo-authored-by: Junie <caleb.cushing+junie@gmail.com>
