### PR TITLE
fix(publish): correct publication name in PublishPluginTest

### DIFF
--- a/module/publish/src/test/java/com/xenoterracide/gradle/convention/publish/PublishPluginTest.java
+++ b/module/publish/src/test/java/com/xenoterracide/gradle/convention/publish/PublishPluginTest.java
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
 //
 // SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 package com.xenoterracide.gradle.convention.publish;
 
@@ -32,7 +33,7 @@ class PublishPluginTest {
       .getExtensions()
       .getByType(PublishingExtension.class)
       .publications(publications -> {
-        publications.register("mavenJava", MavenPublication.class, mavenPublication -> {
+        publications.register("maven", MavenPublication.class, mavenPublication -> {
           mavenPublication.from(project.getComponents().getByName("java"));
         });
       });


### PR DESCRIPTION
The PublishPlugin expects a publication named 'maven' to wire the 'stagingPath' task. Changing 'mavenJava' to 'maven' in the test setup resolves the UnknownTaskException.