### PR TITLE
fix(publish): normalize jar names for modules

### DIFF
--- a/module/publish/src/main/java/com/xenoterracide/gradle/convention/publish/PublishPlugin.java
+++ b/module/publish/src/main/java/com/xenoterracide/gradle/convention/publish/PublishPlugin.java
@@ -12,6 +12,7 @@ import org.gradle.api.Project;
 import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.jvm.tasks.Jar;
 
 /**
  * Plugin for configuring publishinga java to a repository host.
@@ -106,5 +107,13 @@ public class PublishPlugin implements Plugin<Project> {
         maven.setUrl(project.getLayout().getBuildDirectory().dir(STAGING_REPO));
       });
     });
+
+    var tasks = project.getTasks();
+    tasks
+      .withType(Jar.class)
+      .configureEach(jar -> {
+        // ensure output jar is essentially projectroot-module.jar when published to avoid doing this all the time
+        jar.getArchiveBaseName().set(project.getPath().substring(1).replace(":", "-"));
+      });
   }
 }

--- a/module/publish/src/main/java/com/xenoterracide/gradle/convention/publish/PublishPlugin.java
+++ b/module/publish/src/main/java/com/xenoterracide/gradle/convention/publish/PublishPlugin.java
@@ -15,7 +15,7 @@ import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.jvm.tasks.Jar;
 
 /**
- * Plugin for configuring publishinga java to a repository host.
+ * Plugin for configuring publishing Java to a repository host.
  */
 public class PublishPlugin implements Plugin<Project> {
 

--- a/module/publish/src/main/java/com/xenoterracide/gradle/convention/publish/PublishPlugin.java
+++ b/module/publish/src/main/java/com/xenoterracide/gradle/convention/publish/PublishPlugin.java
@@ -112,7 +112,7 @@ public class PublishPlugin implements Plugin<Project> {
     tasks
       .withType(Jar.class)
       .configureEach(jar -> {
-        // ensure output jar is essentially projectroot-module.jar when published to avoid doing this all the time
+        // ensure the output jar is essentially projectroot-module.jar when published to avoid doing this all the time
         jar.getArchiveBaseName().set(project.getPath().substring(1).replace(":", "-"));
       });
   }

--- a/module/publish/src/test/java/com/xenoterracide/gradle/convention/publish/PublishPluginTest.java
+++ b/module/publish/src/test/java/com/xenoterracide/gradle/convention/publish/PublishPluginTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
+// SPDX-FileCopyrightText: Copyright © 2024 - 2026 Caleb Cushing
 //
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
@@ -7,10 +7,12 @@ package com.xenoterracide.gradle.convention.publish;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
+import java.util.Set;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.jvm.tasks.Jar;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,5 +67,56 @@ class PublishPluginTest {
     assertThat(resolver.getCloneUrl().get()).hasToString("https://example.org/user/that.hg");
     assertThat(resolver.getPackageUrl().get()).hasToString("https://package.example.org/user/that");
     assertThat(resolver.getDeveloperConnection().get()).isEqualTo("scm:hg:https://example.org/user/that.hg");
+  }
+
+  @Test
+  void jarArchiveBaseNameDerivedFromProjectPath() {
+    var root = ProjectBuilder.builder().withName("root").build();
+    var parent = ProjectBuilder.builder().withParent(root).withName("a").build();
+    var child = ProjectBuilder.builder().withParent(parent).withName("b").build();
+
+    child.getPluginManager().apply(JavaLibraryPlugin.class);
+    child.getPluginManager().apply(PublishPlugin.class);
+
+    // ensure a Jar task exists (from Java plugin)
+    var jar = (Jar) child.getTasks().getByName("jar");
+    assertThat(jar.getArchiveBaseName().get()).isEqualTo("a-b");
+  }
+
+  @Test
+  void pomIsConfiguredFromProjectAndRepositoryMetadata() {
+    // set some project values
+    project.setDescription("A sample project");
+    publicationLegal.getInceptionYear().set(2024);
+    publicationLegal.getSpdxLicenseIdentifiers().set(Set.of("Apache-2.0"));
+
+    // configure repository host like GitHub and namespace
+    new GithubPublicRepositoryConfiguration().execute(repositoryHost);
+    repositoryHost.getNamespace().set("xenoterracide");
+
+    var publishing = project.getExtensions().getByType(PublishingExtension.class);
+    var pub = (MavenPublication) publishing.getPublications().getByName("maven");
+
+    var pom = pub.getPom();
+    assertThat(pom.getName().get()).isEqualTo(project.getName());
+    assertThat(pom.getDescription().get()).isEqualTo(project.getDescription());
+    assertThat(pom.getInceptionYear().get()).isEqualTo("2024");
+
+    // Note: Detailed assertions on nested POM sections (developers/licenses/scm)
+    // are omitted here due to limited read accessors in the TestFixtures API.
+  }
+
+  @Test
+  void groupAndVersionMirrorRootProject() {
+    var root = ProjectBuilder.builder().withName("root").build();
+    root.setGroup("com.example");
+    root.setVersion("1.2.3");
+
+    var sub = ProjectBuilder.builder().withParent(root).withName("lib").build();
+    sub.getPluginManager().apply(JavaLibraryPlugin.class);
+    sub.getPluginManager().apply(PublishPlugin.class);
+
+    assertThat(sub.getGroup()).isEqualTo(root.getGroup());
+    assertThat(sub.getVersion()).isEqualTo(root.getVersion());
   }
 }


### PR DESCRIPTION
- ensure each Jar task uses the project path to produce a stable 
archiveBaseName that matches module roots
- extend PublishPluginTest to cover the jar name behavior, align 
metadata expectations, and refresh the SPDX year to 2026
