### PR TITLE
chore(build): simplify javadoc tags and npm scripts

### DIFF
--- a/buildSrc/src/main/kotlin/our.convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/our.convention.gradle.kts
@@ -61,12 +61,11 @@ tasks.withType<Javadoc>().configureEach {
   dependsOn(tasks.classes)
   source(sourceSets.main.map { it.output.generatedSourcesDirs })
   (options as StandardJavadocDocletOptions).apply {
-    addMultilineStringsOption("tag").value =
-      listOf(
-        "apiSpec:a:API Spec:",
-        "apiNote:a:API Note:",
-        "implSpec:a:Implementation Spec:",
-        "implNote:a:Implementation Note:",
-      )
+    tags(
+      "apiSpec:a:API Spec:",
+      "apiNote:a:API Note:",
+      "implSpec:a:Implementation Spec:",
+      "implNote:a:Implementation Note:",
+    )
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "rimraf": "^6.1.2"
   },
   "scripts": {
+    "cleaner": "rimraf ./build */build ./module/*/build ./.gradle",
     "contributor": "pip install -r requirements.txt && git config core.hooksPath .config/git/hooks",
     "dependencies:for": "./gradlew dependencies --configuration",
     "merge": "make merge",
     "test": "./gradlew check",
     "ug": "./gradlew dependencies --write-locks --console=plain | grep -e FAILED || exit 0",
-    "ug:scan": "./gradlew dependencies --write-locks --console=plain --scan | grep -e FAILED -e https || exit 0",
-    "cleaner": "rimraf ./build */build ./module/*/build ./.gradle"
+    "ug:dogfood": "./gradlew dependencies --refresh-dependencies --write-locks --console=plain | grep -e FAILED || exit 0",
+    "ug:scan": "./gradlew dependencies --write-locks --console=plain --scan | grep -e FAILED -e https || exit 0"
   }
 }


### PR DESCRIPTION
- Replaced addMultilineStringsOption with tags() so the custom Javadoc 
tags are configured more idiomatically
- Added dedicated scripts for cleaning build outputs and dogfooding 
dependency locks to keep repo tooling consistent
