### PR TITLE
ci(workflow): pass credentials to release jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,12 +93,18 @@ jobs:
       - run: ./gradlew publishPlugins --validate-only --no-configuration-cache --info
         if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
         env:
+          ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
       - name: Release on GitHub
         if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
         run: |
@@ -110,5 +116,9 @@ jobs:
       - run: ./gradlew publishPlugins --no-configuration-cache --info
         if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
         env:
+          ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}


### PR DESCRIPTION
- add GH username/password env so Gradle publish tasks can authenticate
- expose GPG signing secrets to keep in-memory signing working during 
release
- supply same credentials to the GitHub release step for consistent auth
