### PR TITLE
ci(workflow): align build release steps with staging release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@
 name: build
 on:
   push:
-    tags:
-      - v*
+    branches: ["**"]
+    tags: ["v*"]
   pull_request:
     branches: [develop]
   workflow_call:
@@ -40,6 +40,7 @@ jobs:
           ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
 
   full:
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,12 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
           ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
+      - run: ./gradlew publishAllPublicationsToStagingRepository
+        env:
+          ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
       - id: detect-tag
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
@@ -84,12 +90,6 @@ jobs:
           else
             echo "is_tag=false" >> "$GITHUB_OUTPUT"
           fi
-      - run: ./gradlew publishAllPublicationsToStagingRepository
-        env:
-          ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
-          ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
       - run: ./gradlew publishPlugins --validate-only --no-configuration-cache --info
         if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,12 +77,6 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
           ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
-      - run: ./gradlew publishAllPublicationsToGhRepository --info
-        env:
-          ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
-          ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
       - id: detect-tag
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
@@ -90,6 +84,12 @@ jobs:
           else
             echo "is_tag=false" >> "$GITHUB_OUTPUT"
           fi
+      - run: ./gradlew publishAllPublicationsToStagingRepository
+        env:
+          ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
       - run: ./gradlew publishPlugins --validate-only --no-configuration-cache --info
         if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
         env:
@@ -99,20 +99,16 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-      - name: Release on GitHub
-        if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
+      - run: ./gradlew publishAllPublicationsToGhRepository --info
         env:
-          GH_TOKEN: ${{ github.token }}
           ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
           ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          ./gradlew publishAllPublicationsToStagingRepository
-          export STAGING=$(printf "%s" $(./gradlew stagingPath --quiet))
-          # Use the current tag name for the release
-          gh release create "${GITHUB_REF_NAME}" --generate-notes $STAGING/* --verify-tag
-
+      - run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag $(find "$STAGING" -type f)
+        if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
       - run: ./gradlew publishPlugins --no-configuration-cache --info
         if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
         env:


### PR DESCRIPTION
- allow workflow to run on any branch pushes and separately on tags
- gate full job on pull_request events and streamline publishing targets
- publish to staging before GH release and ensure release creation 
triggers only on tags
