### PR TITLE
ci: fix release to use actual path not variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
 
   publish:
-    needs: [build, full]
+    needs: [build]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
-      - run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag $(find "$STAGING" -type f)
+      - run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag $(find ./build/repo -type f)
         if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- gh release was still using the now unpopulated $STAGING variable
- make publish only depend on build, full will run before merge anyways.