### PR TITLE
ci(build): archive release artifacts as tar.gz

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,10 +83,6 @@ jobs:
           ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
-      - name: output files
-        id: files
-        run: |
-          echo "files=$(find ./module/*/build/repo -type f | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
       - name: detect tag
         id: detect-tag
         run: |
@@ -110,7 +106,22 @@ jobs:
           ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
-      - run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag ${{ steps.files.outputs.files }}
+      - name: create release archives
+        id: archives
+        if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
+        run: |
+          mkdir -p release-archives
+          for module_dir in ./module/*/build/repo; do
+            # Extract module name: ./module/<name>/build/repo -> <name>
+            module_name=$(basename "$(dirname "$(dirname "$module_dir")")")
+            # Create tar.gz with complete Maven repository structure
+            # Includes: artifacts, signatures (.asc), checksums, and maven-metadata.xml
+            tar -czf "release-archives/${module_name}-${GITHUB_REF_NAME}.tar.gz" \
+              -C "$(dirname "$module_dir")" \
+              "$(basename "$module_dir")"
+          done
+          ls -la release-archives/
+      - run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag release-archives/*.tar.gz
         if: ${{ steps.detect-tag.outputs.is_tag == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Change the release workflow to create tar.gz archives for each module's
Maven repository instead of attaching individual files.

- Remove the "output files" step that collected individual file paths
- Add "create release archives" step to package each module's build/repo
  directory into a tar.gz file
- Update gh release create to use the archived files instead of
  individual artifacts

This simplifies the release process and ensures all artifacts (including
signatures, checksums, and maven-metadata.xml) are bundled together.