### PR TITLE
ci(build): add version task to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5.0.1
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-      - run: ./gradlew build --console=plain
+      - run: ./gradlew version build --console=plain
         env:
           ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
           ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}


### PR DESCRIPTION
Add the `version` task to the GitHub Actions build workflow to print
project version information before building.

- Modify `./gradlew build` to `./gradlew version build` in build.yml
- Provides visibility into the project version during CI runs
- Helps with debugging and verification of version configuration