### PR TITLE
ci(build): add concurrency group to publish job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,8 @@ jobs:
       actions: read
       contents: write
       packages: write
+    concurrency:
+      group: publish
     env:
       IS_PUBLISHING: true
     steps:


### PR DESCRIPTION
Add concurrency configuration to the publish job in the build workflow
to prevent multiple publish jobs from running simultaneously. This
ensures that only one publish operation occurs at a time, avoiding
potential race conditions or conflicts when deploying artifacts.