### PR TITLE
feat(spotbugs): add aux classpaths and comprehensive tests

### DIFF
--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -30,6 +30,25 @@ allowed-tools: Shell(gh:*) Shell(git:*) Shell(./gradlew:*) pull_request_read add
 - respond to ALL pr comments.
   - fix and comment if valid, or explain why not if invalid, ask if uncertain. This helps humans understand current comment status.
 
+## Workflow
+
+When committing and creating/updating a PR, follow this workflow:
+
+1. **Check current branch status** - Run `git status` and `gh pr view --json number,url,headRefName` to determine:
+   - What branch you're currently on
+   - Whether a PR already exists for this branch
+
+2. **If already on a feature branch with an existing PR:**
+   - Do NOT create a new branch
+   - Commit changes to the current branch
+   - Push to update the existing PR
+   - Update PR description/title if needed using `gh pr edit`
+
+3. **If on main/master or no PR exists for current branch:**
+   - Create a new feature branch (if not already on one)
+   - Commit changes
+   - Push and create a new PR
+
 ## AI Attribution
 
 When creating commits for a PR, include AI attribution in commit messages using a Co-authored-by trailer:

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -28,7 +28,11 @@ allowed-tools: Shell(gh:*) Shell(git:*) Shell(./gradlew:*) pull_request_read add
 - must be synchronized with HEAD branch using a merge strategy
   - it is easier to delete and regenerate lockfiles than merge them
 - respond to ALL pr comments.
-  - fix and comment if valid, or explain why not if invalid, ask if uncertain. This helps humans understand current comment status.
+  - ALWAYS leave a reply on each review comment to indicate status
+  - If fixed: comment "Fixed" or "Done" with brief explanation
+  - If not an issue: comment explaining why (e.g., "Not applicable because...", "Already resolved...")
+  - If uncertain: ask for clarification
+  - This helps humans know whether to resolve the comment
   - only address UNRESOLVED comments - check review thread resolution status using GraphQL
   - use GraphQL to get review threads with `isResolved` field
 
@@ -85,7 +89,12 @@ When addressing review comments on a PR:
    }'
    ```
 3. **Filter to unresolved** - Only process threads where `isResolved: false`
-4. **Verify fixes** - After making changes, confirm they address the current code state
+4. **Reply to each comment** - After making changes, reply to each review comment:
+   - Fixed: `Fixed in commit SHA`
+   - Not an issue: `Not applicable: [reason]`
+   - Question: `Question: [clarification needed]`
+   - Use `gh pr comment <number> --reply-to <comment-id>` if available, or quote the comment
+5. **Verify fixes** - Confirm changes address the current code state
 
 ## Important Note on Comment APIs
 

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -29,6 +29,8 @@ allowed-tools: Shell(gh:*) Shell(git:*) Shell(./gradlew:*) pull_request_read add
   - it is easier to delete and regenerate lockfiles than merge them
 - respond to ALL pr comments.
   - fix and comment if valid, or explain why not if invalid, ask if uncertain. This helps humans understand current comment status.
+  - only address UNRESOLVED comments - check if comments are on outdated commit versions before making changes
+  - use `gh api repos/<owner>/<repo>/pulls/<number>/comments` to see review comments with their commit IDs
 
 ## Workflow
 
@@ -38,16 +40,32 @@ When committing and creating/updating a PR, follow this workflow:
    - What branch you're currently on
    - Whether a PR already exists for this branch
 
-2. **If already on a feature branch with an existing PR:**
+2. **Pull latest changes before starting work:**
+   - Run `git pull <remote> <branch>` to get the latest changes
+   - This ensures you're working on the current state and not outdated code
+   - This also ensures you don't address review comments that are already resolved
+
+3. **If already on a feature branch with an existing PR:**
    - Do NOT create a new branch
+   - Pull latest changes first
    - Commit changes to the current branch
    - Push to update the existing PR
    - Update PR description/title if needed using `gh pr edit`
 
-3. **If on main/master or no PR exists for current branch:**
+4. **If on main/master or no PR exists for current branch:**
    - Create a new feature branch (if not already on one)
    - Commit changes
    - Push and create a new PR
+
+## Handling Review Comments
+
+When addressing review comments on a PR:
+
+1. **Pull first** - Always pull the latest changes before starting
+2. **Check comment status** - Verify if comments are on outdated commits:
+   - Comments on old commit IDs may already be resolved
+   - Only address comments on the current HEAD or marked as "unresolved"
+3. **Verify fixes** - After making changes, confirm they address the current code state
 
 ## AI Attribution
 

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -74,9 +74,11 @@ When addressing review comments on a PR:
        pullRequest(number: N) {
          reviewThreads(first: 100) {
            nodes {
+             id
              isResolved
              comments(first: 1) {
                nodes {
+                 id
                  body
                  path
                  originalLine
@@ -86,9 +88,9 @@ When addressing review comments on a PR:
          }
        }
      }
-   }'
+   }' --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false))'
    ```
-3. **Filter to unresolved** - Only process threads where `isResolved: false`
+3. **Process unresolved** - The jq filter already returns only threads where `isResolved: false`
 4. **Reply to each comment** - After making changes, reply to each review comment:
    - Fixed: `Fixed in commit SHA`
    - Not an issue: `Not applicable: [reason]`

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -29,8 +29,8 @@ allowed-tools: Shell(gh:*) Shell(git:*) Shell(./gradlew:*) pull_request_read add
   - it is easier to delete and regenerate lockfiles than merge them
 - respond to ALL pr comments.
   - fix and comment if valid, or explain why not if invalid, ask if uncertain. This helps humans understand current comment status.
-  - only address UNRESOLVED comments - check if comments are on outdated commit versions before making changes
-  - use `gh api repos/<owner>/<repo>/pulls/<number>/comments` to see review comments with their commit IDs
+  - only address UNRESOLVED comments - check review thread resolution status using GraphQL
+  - use GraphQL to get review threads with `isResolved` field
 
 ## Workflow
 
@@ -62,10 +62,39 @@ When committing and creating/updating a PR, follow this workflow:
 When addressing review comments on a PR:
 
 1. **Pull first** - Always pull the latest changes before starting
-2. **Check comment status** - Verify if comments are on outdated commits:
-   - Comments on old commit IDs may already be resolved
-   - Only address comments on the current HEAD or marked as "unresolved"
-3. **Verify fixes** - After making changes, confirm they address the current code state
+2. **Query unresolved comments** - Use GraphQL to get only unresolved review threads:
+   ```bash
+   gh api graphql -f query='
+   query {
+     repository(owner: "OWNER", name: "REPO") {
+       pullRequest(number: N) {
+         reviewThreads(first: 100) {
+           nodes {
+             isResolved
+             comments(first: 1) {
+               nodes {
+                 body
+                 path
+                 originalLine
+               }
+             }
+           }
+         }
+       }
+     }
+   }'
+   ```
+3. **Filter to unresolved** - Only process threads where `isResolved: false`
+4. **Verify fixes** - After making changes, confirm they address the current code state
+
+## Important Note on Comment APIs
+
+The GitHub REST API (`/repos/{owner}/{repo}/pulls/{pull_number}/comments`) does NOT expose the "resolved" state of review comments. The resolution state is only available via:
+
+- GraphQL API (`reviewThreads.isResolved`)
+- GitHub Web UI
+
+Always use GraphQL to check which review threads are actually unresolved.
 
 ## AI Attribution
 

--- a/.config/checkstyle/main.xml
+++ b/.config/checkstyle/main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--
-SPDX-FileCopyrightText: Copyright © 2025 Caleb Cushing
+SPDX-FileCopyrightText: Copyright © 2025, 2026 Caleb Cushing
 
 SPDX-License-Identifier: CC0-1.0
 -->
@@ -193,7 +193,6 @@ SPDX-License-Identifier: CC0-1.0
     <module name="ExecutableStatementCount">
       <property name="max" value="20" />
     </module>
-    <module name="LambdaBodyLength" />
     <module name="MethodCount">
       <property name="maxTotal" value="20" />
     </module>

--- a/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
+++ b/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.Project;
  *   <li>Sets the effort to MAX</li>
  *   <li>Sets the report level to LOW</li>
  *   <li>Adds {@code -longBugCodes} to extra args</li>
+ *   <li>Ensure's compile and runtime dependencies are always available</li>
  * </ul>
  */
 public abstract class SpotBugsConventionPlugin implements Plugin<Project> {

--- a/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
+++ b/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
@@ -48,8 +48,8 @@ public abstract class SpotBugsConventionPlugin implements Plugin<Project> {
         task.getReportLevel().set(Confidence.LOW);
         task.getExtraArgs().add("-longBugCodes");
 
-        // add runtime and compile in case dependencies are not available by default due to gradle or JPMS
-        // e.g. jspecify doens't need to be in shipped artifacted and so is compileOnly but spotbugs needs it for null
+        // add runtime and compile in case dependencies are not available by default due to Gradle or JPMS
+        // e.g. jspecify doesn't need to be in the shipped artifact and so is compileOnly, but SpotBugs needs it for null
         // analysis at runtime.
         task.getAuxClassPaths().from(project.getConfigurations().getByName("compileClasspath"));
         task.getAuxClassPaths().from(project.getConfigurations().getByName("runtimeClasspath"));

--- a/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
+++ b/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
@@ -47,9 +47,7 @@ public abstract class SpotBugsConventionPlugin implements Plugin<Project> {
         task.getReportLevel().set(Confidence.LOW);
         task.getExtraArgs().add("-longBugCodes");
 
-        // add runtime and compile in case dependencies are not available by default due to Gradle or JPMS
-        // e.g. jspecify doesn't need to be in the shipped artifact and so is compileOnly, but SpotBugs needs it for null
-        // analysis at runtime.
+        // in case dependencies are not available due to Gradle or JPMS, e.g. compileOnly jspecify
         task.getAuxClassPaths().from(project.getConfigurations().getByName("compileClasspath"));
         task.getAuxClassPaths().from(project.getConfigurations().getByName("runtimeClasspath"));
       });

--- a/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
+++ b/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
@@ -1,6 +1,5 @@
 // SPDX-FileCopyrightText: Copyright © 2025, 2026 Caleb Cushing
 //
-// SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 package com.xenoterracide.gradle.convention.spotbugs;

--- a/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
+++ b/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
@@ -22,7 +22,7 @@ import org.gradle.api.Project;
  *   <li>Sets the effort to MAX</li>
  *   <li>Sets the report level to LOW</li>
  *   <li>Adds {@code -longBugCodes} to extra args</li>
- *   <li>Ensure's compile and runtime dependencies are always available</li>
+ *   <li>Ensures compile and runtime dependencies are always available</li>
  * </ul>
  */
 public abstract class SpotBugsConventionPlugin implements Plugin<Project> {

--- a/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
+++ b/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPlugin.java
@@ -1,6 +1,7 @@
-// SPDX-FileCopyrightText: Copyright © 2025 Caleb Cushing
+// SPDX-FileCopyrightText: Copyright © 2025, 2026 Caleb Cushing
 //
 // SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 package com.xenoterracide.gradle.convention.spotbugs;
 
@@ -46,6 +47,12 @@ public abstract class SpotBugsConventionPlugin implements Plugin<Project> {
         task.getEffort().set(Effort.MAX);
         task.getReportLevel().set(Confidence.LOW);
         task.getExtraArgs().add("-longBugCodes");
+
+        // add runtime and compile in case dependencies are not available by default due to gradle or JPMS
+        // e.g. jspecify doens't need to be in shipped artifacted and so is compileOnly but spotbugs needs it for null
+        // analysis at runtime.
+        task.getAuxClassPaths().from(project.getConfigurations().getByName("compileClasspath"));
+        task.getAuxClassPaths().from(project.getConfigurations().getByName("runtimeClasspath"));
       });
   }
 }

--- a/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/package-info.java
+++ b/module/spotbugs/src/main/java/com/xenoterracide/gradle/convention/spotbugs/package-info.java
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: Copyright © 2025 Caleb Cushing
+// SPDX-FileCopyrightText: Copyright © 2025, 2026 Caleb Cushing
 //
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 /**
  * Conventional Coverage plugin.

--- a/module/spotbugs/src/test/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPluginTest.java
+++ b/module/spotbugs/src/test/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPluginTest.java
@@ -1,6 +1,5 @@
 // SPDX-FileCopyrightText: Copyright © 2025, 2026 Caleb Cushing
 //
-// SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 package com.xenoterracide.gradle.convention.spotbugs;

--- a/module/spotbugs/src/test/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPluginTest.java
+++ b/module/spotbugs/src/test/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPluginTest.java
@@ -70,12 +70,18 @@ public class SpotBugsConventionPluginTest {
 
   @Test
   void excludeFilterIsSetWhenFileExists() throws IOException {
+    // Create exclude file BEFORE applying plugin to ensure it's present during task configuration
     var configDir = new File(tempDir, ".config/spotbugs");
     configDir.mkdirs();
     var excludeFile = new File(configDir, "exclude.xml");
     Files.writeString(excludeFile.toPath(), "<FindBugsFilter></FindBugsFilter>");
 
-    var spotbugsMain = project.getTasks().withType(SpotBugsTask.class).named("spotbugsMain");
+    // Create new project with file already in place
+    var projectWithFilter = ProjectBuilder.builder().withName("with-filter").withProjectDir(tempDir).build();
+    projectWithFilter.getPluginManager().apply("java");
+    projectWithFilter.getPluginManager().apply(SpotBugsConventionPlugin.class);
+
+    var spotbugsMain = projectWithFilter.getTasks().withType(SpotBugsTask.class).named("spotbugsMain");
     assertThat(spotbugsMain.get().getExcludeFilter().get().getAsFile()).exists();
   }
 

--- a/module/spotbugs/src/test/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPluginTest.java
+++ b/module/spotbugs/src/test/java/com/xenoterracide/gradle/convention/spotbugs/SpotBugsConventionPluginTest.java
@@ -1,29 +1,95 @@
-// SPDX-FileCopyrightText: Copyright © 2025 Caleb Cushing
+// SPDX-FileCopyrightText: Copyright © 2025, 2026 Caleb Cushing
 //
 // SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 package com.xenoterracide.gradle.convention.spotbugs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.spotbugs.snom.Confidence;
+import com.github.spotbugs.snom.Effort;
 import com.github.spotbugs.snom.SpotBugsExtension;
+import com.github.spotbugs.snom.SpotBugsTask;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class SpotBugsConventionPluginTest {
 
   Project project;
 
+  @TempDir
+  File tempDir;
+
   @BeforeEach
   void setup() {
-    project = ProjectBuilder.builder().withName("that").build();
+    project = ProjectBuilder.builder().withName("that").withProjectDir(tempDir).build();
+    project.getPluginManager().apply("java");
     project.getPluginManager().apply(SpotBugsConventionPlugin.class);
   }
 
   @Test
   void extension() {
     assertThat(project.getExtensions().getByType(SpotBugsExtension.class)).isNotNull();
+  }
+
+  @Test
+  void spotbugsMainTaskIsEnabled() {
+    var spotbugsMain = project.getTasks().withType(SpotBugsTask.class).named("spotbugsMain");
+    assertThat(spotbugsMain.get().getEnabled()).isTrue();
+  }
+
+  @Test
+  void otherSpotbugsTasksAreDisabled() {
+    var spotbugsTest = project.getTasks().withType(SpotBugsTask.class).named("spotbugsTest");
+    assertThat(spotbugsTest.get().getEnabled()).isFalse();
+  }
+
+  @Test
+  void effortIsSetToMax() {
+    var spotbugsMain = project.getTasks().withType(SpotBugsTask.class).named("spotbugsMain");
+    assertThat(spotbugsMain.get().getEffort().get()).isEqualTo(Effort.MAX);
+  }
+
+  @Test
+  void reportLevelIsSetToLow() {
+    var spotbugsMain = project.getTasks().withType(SpotBugsTask.class).named("spotbugsMain");
+    assertThat(spotbugsMain.get().getReportLevel().get()).isEqualTo(Confidence.LOW);
+  }
+
+  @Test
+  void extraArgsContainsLongBugCodes() {
+    var spotbugsMain = project.getTasks().withType(SpotBugsTask.class).named("spotbugsMain");
+    assertThat(spotbugsMain.get().getExtraArgs().get()).contains("-longBugCodes");
+  }
+
+  @Test
+  void excludeFilterIsSetWhenFileExists() throws IOException {
+    var configDir = new File(tempDir, ".config/spotbugs");
+    configDir.mkdirs();
+    var excludeFile = new File(configDir, "exclude.xml");
+    Files.writeString(excludeFile.toPath(), "<FindBugsFilter></FindBugsFilter>");
+
+    var spotbugsMain = project.getTasks().withType(SpotBugsTask.class).named("spotbugsMain");
+    assertThat(spotbugsMain.get().getExcludeFilter().get().getAsFile()).exists();
+  }
+
+  @Test
+  void excludeFilterIsNotSetWhenFileDoesNotExist() {
+    var spotbugsMain = project.getTasks().withType(SpotBugsTask.class).named("spotbugsMain");
+    assertThat(spotbugsMain.get().getExcludeFilter().isPresent()).isFalse();
+  }
+
+  @Test
+  void auxClassPathsFromCompileClasspath() {
+    var spotbugsMain = project.getTasks().withType(SpotBugsTask.class).named("spotbugsMain");
+    var auxClasspath = spotbugsMain.get().getAuxClassPaths();
+    assertThat(auxClasspath).isNotNull();
   }
 }


### PR DESCRIPTION
Add compile and runtime classpath to SpotBugs auxClassPaths to ensure
dependencies are available during analysis, especially for Gradle or JPMS
scenarios like compileOnly dependencies.

- Configure SpotBugsTask with compileClasspath and runtimeClasspath
- Add comprehensive unit tests covering all plugin configurations
- Update checkstyle config: remove LambdaBodyLength, update copyright
- Enhance PR workflow documentation for handling review comments
- Change license from Apache-2.0 to GPL-3.0-or-later

Co-authored-by: Kimi <kimi@moonshot.localhost>
