### PR TITLE
ci(github): refactor workflows to use reusable workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,6 +52,13 @@
     },
     {
       matchManagers: ["github-actions"],
+      rangeStrategy: "pin", // always prefer v1.2.3
+      automerge: true,
+    },
+    {
+      matchManagers: ["github-actions"],
+      matchPackagePatterns: ["^xenoterracide/github/"],
+      pinDigests: true, // use sha's
       automerge: true,
     },
     {

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,9 +6,9 @@ name: precommit
 on: [push, workflow_call]
 jobs:
   license:
-    uses: xenoterracide/github/.github/workflows/license.yml@4638b8c9a7a42c42d70da79ed3491a301433a6a1
+    uses: xenoterracide/github/.github/workflows/license.yml@develop
   format:
-    uses: xenoterracide/github/.github/workflows/format.yml@4638b8c9a7a42c42d70da79ed3491a301433a6a1
+    uses: xenoterracide/github/.github/workflows/format.yml@develop
   format-kotlin:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,29 +6,9 @@ name: precommit
 on: [push, workflow_call]
 jobs:
   license:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: astral-sh/setup-uv@v7
-      - run: uv sync --frozen
-      - run: uv run reuse lint
+    uses: xenoterracide/github/.github/workflows/license.yml@4638b8c9a7a42c42d70da79ed3491a301433a6a1
   format:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.3.0
-        with:
-          node-version: 24
-          package-manager-cache: false
-      - run: corepack enable
-      - uses: actions/setup-node@v6.3.0
-        with:
-          node-version: 24
-          cache: "yarn"
-      - run: yarn install --immutable --inline-builds --check-resolutions
-      - run: yarn exec prettier --ignore-unknown --check '**'
+    uses: xenoterracide/github/.github/workflows/format.yml@4638b8c9a7a42c42d70da79ed3491a301433a6a1
   format-kotlin:
     runs-on: ubuntu-24.04
     steps:
@@ -36,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 21
       - uses: asdf-vm/actions/plugins-add@v4.0.1
       - run: asdf install ktlint
       - run: ktlint '*.gradle.kts' '**/*.gradle.kts'

--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -8,64 +8,14 @@ on:
     - cron: "0 3 * * *"
   push:
     branches:
-      - ci/auto-update-java
-      - ci/auto-update
-
+      - "ci/auto-update**"
 jobs:
   update-java:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    uses: xenoterracide/github/.github/workflows/update-java.yml@4638b8c9a7a42c42d70da79ed3491a301433a6a1
+    secrets:
+      gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+      merge_pat: ${{ secrets.GH_MERGE_PAT }}
     permissions:
       contents: read
       packages: read
-    env:
-      ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
-      ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
-    steps:
-      - uses: actions/checkout@v6.0.2
-        with:
-          ref: ${{ github.ref }}
-          filter: "blob:none"
-          fetch-depth: 0
-      - uses: actions/setup-java@v5.2.0
-        with:
-          distribution: temurin
-          java-version: 25
-      - uses: astral-sh/setup-uv@v7
-      - run: uv sync --frozen
-      - uses: gradle/actions/setup-gradle@v5.0.2
-        with:
-          gradle-version: current
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-        # update the version of gradlew
-      - run: gradle wrapper --write-locks
-      - run: find . -name '*gradle.lockfile' -delete
-        # fetch the actual wrapper and then update the gradlew scripts
-      - run: ./gradlew wrapper --write-locks && ./gradlew wrapper
-      - run: ./gradlew dependencies --write-locks | grep -e FAILED -e https
-      - run: ./gradlew build --write-locks
-      - run: |
-          echo "stdout<<EOF" >> $GITHUB_OUTPUT
-          git status --porcelain=1 | tee --append $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-        name: git status
-        id: git_status
-      - uses: astral-sh/setup-uv@v7
-        if: ${{ contains(steps.git_status.outputs.stdout, 'gradle/wrapper/') }}
-      - run: uv sync --frozen
-        if: ${{ contains(steps.git_status.outputs.stdout, 'gradle/wrapper/') }}
-      - run: |
-          uv run reuse annotate --license 'CC0-1.0' --copyright 'Caleb Cushing' \
-            --copyright-prefix spdx-string-symbol --merge-copyrights --force-dot-license gradle/wrapper/gradle-wrapper.properties
-        name: reuse
-        if: ${{ contains(steps.git_status.outputs.stdout, 'gradle-wrapper.jar') }}
-      - uses: peter-evans/create-pull-request@v8.1.0
-        id: create_pr
-        with:
-          title: "chore(deps): java"
-          branch: deps/update-java
-          token: ${{ secrets.GH_MERGE_PAT }}
-      - run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_MERGE_PAT }}
+      pull-requests: write

--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -11,7 +11,7 @@ on:
       - "ci/auto-update**"
 jobs:
   update-java:
-    uses: xenoterracide/github/.github/workflows/update-java.yml@4638b8c9a7a42c42d70da79ed3491a301433a6a1
+    uses: xenoterracide/github/.github/workflows/update-java.yml@develop
     secrets:
       gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       merge_pat: ${{ secrets.GH_MERGE_PAT }}


### PR DESCRIPTION
Refactor GitHub Actions workflows to use centralized reusable workflows from
xenoterracide/github repository and update Renovate configuration for better
GitHub Actions dependency management.

- Replace inline license job with reusable xenoterracide/github/.github/workflows/license.yml
- Replace inline format job with reusable xenoterracide/github/.github/workflows/format.yml
- Replace entire update-java workflow with reusable xenoterracide/github/.github/workflows/update-java.yml
- Update Renovate config to pin GitHub Actions versions and use SHA digests for internal actions
- Downgrade ktlint Java version from 25 to 21 for compatibility
- Simplify update-java branch pattern matching to "ci/auto-update**"

Co-authored-by: Kimi <kimi@moonshot.localhost>
