### PR TITLE
ci(github): use reusable workflows from xenoterracide/github

### DIFF
--- a/.agents/skills/java/SKILL.md
+++ b/.agents/skills/java/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: java
-license: CC-BY-NC-SA-4.0
 description: Write code in the Java programming language.
 # SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
 #

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,6 +55,7 @@
     {
       matchManagers: ["github-actions"],
       automerge: true,
+      pinDigest: true,
     },
     {
       // Run every Wednesday

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,7 +55,6 @@
     {
       matchManagers: ["github-actions"],
       automerge: true,
-      pinDigest: true,
     },
     {
       // Pin xenoterracide org actions to commit SHAs for security

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,14 @@
       automerge: true,
     },
     {
+      // Pin xenoterracide org actions to commit SHAs for security
+      // Only these get digest pins; other actions get normal version tag updates
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["xenoterracide/**"],
+      automerge: true,
+      pinDigest: true,
+    },
+    {
       // Run every Wednesday
       // Window: 04:00 UTC hour on Wednesday (Renovate cron uses '*' for minutes)
       schedule: ["* 4 * * 3"],

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,37 +6,8 @@ name: precommit
 on: [push, workflow_call]
 jobs:
   license:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: astral-sh/setup-uv@v7
-      - run: uv sync --frozen
-      - run: uv run reuse lint
-  format:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.3.0
-        with:
-          node-version: 24
-          package-manager-cache: false
-      - run: corepack enable
-      - uses: actions/setup-node@v6.3.0
-        with:
-          node-version: 24
-          cache: "yarn"
-      - run: yarn install --immutable --inline-builds --check-resolutions
-      - run: yarn exec prettier --ignore-unknown --check '**'
-  format-kotlin:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-java@v5.2.0
-        with:
-          distribution: temurin
-          java-version: 25
-      - uses: asdf-vm/actions/plugins-add@v4.0.1
-      - run: asdf install ktlint
-      - run: ktlint '*.gradle.kts' '**/*.gradle.kts'
+    uses: xenoterracide/github/.github/workflows/license.yml@develop
+  prettier:
+    uses: xenoterracide/github/.github/workflows/prettier.yml@develop
+  kotlin:
+    uses: xenoterracide/github/.github/workflows/ktlint.yml@develop

--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -8,64 +8,8 @@ on:
     - cron: "0 3 * * *"
   push:
     branches:
-      - ci/auto-update-java
       - ci/auto-update
 
 jobs:
   update-java:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      packages: read
-    env:
-      ORG_GRADLE_PROJECT_ghUsername: ${{ github.actor }}
-      ORG_GRADLE_PROJECT_ghPassword: ${{ github.token }}
-    steps:
-      - uses: actions/checkout@v6.0.2
-        with:
-          ref: ${{ github.ref }}
-          filter: "blob:none"
-          fetch-depth: 0
-      - uses: actions/setup-java@v5.2.0
-        with:
-          distribution: temurin
-          java-version: 25
-      - uses: astral-sh/setup-uv@v7
-      - run: uv sync --frozen
-      - uses: gradle/actions/setup-gradle@v5.0.2
-        with:
-          gradle-version: current
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-        # update the version of gradlew
-      - run: gradle wrapper --write-locks
-      - run: find . -name '*gradle.lockfile' -delete
-        # fetch the actual wrapper and then update the gradlew scripts
-      - run: ./gradlew wrapper --write-locks && ./gradlew wrapper
-      - run: ./gradlew dependencies --write-locks | grep -e FAILED -e https
-      - run: ./gradlew build --write-locks
-      - run: |
-          echo "stdout<<EOF" >> $GITHUB_OUTPUT
-          git status --porcelain=1 | tee --append $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-        name: git status
-        id: git_status
-      - uses: astral-sh/setup-uv@v7
-        if: ${{ contains(steps.git_status.outputs.stdout, 'gradle/wrapper/') }}
-      - run: uv sync --frozen
-        if: ${{ contains(steps.git_status.outputs.stdout, 'gradle/wrapper/') }}
-      - run: |
-          uv run reuse annotate --license 'CC0-1.0' --copyright 'Caleb Cushing' \
-            --copyright-prefix spdx-string-symbol --merge-copyrights --force-dot-license gradle/wrapper/gradle-wrapper.properties
-        name: reuse
-        if: ${{ contains(steps.git_status.outputs.stdout, 'gradle-wrapper.jar') }}
-      - uses: peter-evans/create-pull-request@v8.1.0
-        id: create_pr
-        with:
-          title: "chore(deps): java"
-          branch: deps/update-java
-          token: ${{ secrets.GH_MERGE_PAT }}
-      - run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_MERGE_PAT }}
+    uses: xenoterracide/github/.github/workflows/update-java.yml@develop

--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -6,9 +6,6 @@ name: update-java
 on:
   schedule:
     - cron: "0 3 * * *"
-  push:
-    branches:
-      - ci/auto-update
 
 jobs:
   update-java:

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -24,6 +24,6 @@ path = ".python-version"
 SPDX-FileCopyrightText = "NONE"
 SPDX-License-Identifier = "CC0-1.0"
 [[annotations]]
-path = "gradle/wrapper/gradle-wrapper.jar"
+path = "gradle/wrapper/*"
 SPDX-FileCopyrightText = "See MANIFEST.MF in jar"
 SPDX-License-Identifier = "Apache-2.0"

--- a/gradle/wrapper/gradle-wrapper.jar.license
+++ b/gradle/wrapper/gradle-wrapper.jar.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: Copyright © 2025 - 2026 Gradle, Inc
-
-SPDX-License-Identifier: Apache-2.0

--- a/gradle/wrapper/gradle-wrapper.properties.license
+++ b/gradle/wrapper/gradle-wrapper.properties.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: Copyright © 2025 - 2026 Caleb Cushing
-
-SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
Refactor GitHub workflows to use centralized reusable workflows from the
xenoterracide/github repository, reducing maintenance burden and ensuring
consistency across projects.

- Replace inline license, prettier, and ktlint jobs in pre-commit.yml with
  reusable workflows (license.yml, prettier.yml, ktlint.yml)
- Replace inline update-java job with reusable update-java.yml workflow
- Add Renovate configuration to pin xenoterracide org actions to commit SHAs
  for security while allowing normal version updates for other actions
- Update REUSE.toml to use wildcard pattern for gradle wrapper files
- Remove redundant license files for gradle wrapper (now covered by wildcard)
- Remove license field from java skill metadata

Co-authored-by: Kimi <kimi@moonshot.localhost>
