### PR TITLE
chore(renovate): update pinDigest configuration to object format

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,7 +62,9 @@
       matchManagers: ["github-actions"],
       matchPackageNames: ["xenoterracide/**"],
       automerge: true,
-      pinDigest: true,
+      pinDigest: {
+        enabled: true,
+      },
     },
     {
       // Run every Wednesday

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,7 +57,7 @@
       automerge: true,
     },
     {
-      // Pin xenoterracide org actions to commit SHAs for security
+      // Pin xenoterracide org actions to commit SHAs for build reproducibility
       // Only these get digest pins; other actions get normal version tag updates
       matchManagers: ["github-actions"],
       matchPackageNames: ["xenoterracide/**"],


### PR DESCRIPTION
Update the Renovate configuration for pinning xenoterracide org actions
digest SHAs from a boolean value to an object format with an enabled property.

This change also updates the comment to clarify that pinning is for build
reproducibility rather than just security.