### PR TITLE
ci: add required secrets to update-java workflow

### DIFF
--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -10,4 +10,6 @@ on:
 jobs:
   update-java:
     uses: xenoterracide/github/.github/workflows/update-java.yml@develop
-    secrets: inherit
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+      MERGE_PAT: ${{ secrets.MERGE_PAT }}

--- a/.github/workflows/update-java.yml
+++ b/.github/workflows/update-java.yml
@@ -10,3 +10,4 @@ on:
 jobs:
   update-java:
     uses: xenoterracide/github/.github/workflows/update-java.yml@develop
+    secrets: inherit


### PR DESCRIPTION
- Pass GRADLE_ENCRYPTION_KEY secret to reusable workflow
- Pass MERGE_PAT secret to reusable workflow

These secrets are required by the shared update-java workflow
in the xenoterracide/github repository.